### PR TITLE
add tests to swearfilter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ makeevrserg.java.ktarget=17
 # Project
 makeevrserg.project.name=AspeKt
 makeevrserg.project.group=ru.astrainteractive.aspekt
-makeevrserg.project.version.string=2.19.9
+makeevrserg.project.version.string=2.19.10
 makeevrserg.project.description=Essentials plugin for EmpireProjekt
 makeevrserg.project.developers=makeevrserg|Makeev Roman|makeevrserg@gmail.com
 makeevrserg.project.url=https://empireprojekt.ru

--- a/modules/antiswear/src/main/kotlin/ru/astrainteractive/aspekt/module/antiswear/event/SwearRenderer.kt
+++ b/modules/antiswear/src/main/kotlin/ru/astrainteractive/aspekt/module/antiswear/event/SwearRenderer.kt
@@ -3,7 +3,6 @@ package ru.astrainteractive.aspekt.module.antiswear.event
 import io.papermc.paper.chat.ChatRenderer
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.TextReplacementConfig
 import org.bukkit.entity.Player
 import ru.astrainteractive.aspekt.module.antiswear.data.SwearRepository
 import ru.astrainteractive.aspekt.module.antiswear.util.SwearRuRegex
@@ -12,14 +11,6 @@ internal class SwearRenderer(
     private val renderer: ChatRenderer,
     private val swearRepository: SwearRepository
 ) : ChatRenderer {
-    private fun Component.replaceSwears(): Component {
-        val config = TextReplacementConfig.builder()
-            .match(SwearRuRegex.regex.pattern)
-            .replacement("****")
-            .build()
-        return replaceText(config)
-    }
-
     override fun render(
         source: Player,
         sourceDisplayName: Component,
@@ -29,6 +20,6 @@ internal class SwearRenderer(
         val originalMessage = renderer.render(source, sourceDisplayName, message, viewer)
         val player = viewer as? Player ?: return originalMessage
         if (!swearRepository.isSwearFilterEnabled(player)) return originalMessage
-        return originalMessage.replaceSwears()
+        return originalMessage.replaceText(SwearRuRegex.REPLACEMENT_CONFIG)
     }
 }

--- a/modules/antiswear/src/main/kotlin/ru/astrainteractive/aspekt/module/antiswear/util/SwearRuRegex.kt
+++ b/modules/antiswear/src/main/kotlin/ru/astrainteractive/aspekt/module/antiswear/util/SwearRuRegex.kt
@@ -1,9 +1,20 @@
 package ru.astrainteractive.aspekt.module.antiswear.util
 
+import net.kyori.adventure.text.TextReplacementConfig
+
 internal object SwearRuRegex {
-    val regex by lazy {
+    val SWEAR_REGEX by lazy {
         """
             (?iu)\b(?:(?:(?:у|[нз]а|(?:хитро|не)?вз?[ыьъ]|с[ьъ]|(?:и|ра)[зс]ъ?|(?:о[тб]|п[оа]д)[ьъ]?|(?:.\B)+?[оаеи-])-?)?(?:[её](?:б(?!о[рй]|рач)|п[уа](?:ц|тс))|и[пб][ае][тцд][ьъ]).*?|(?:(?:н[иеа]|ра[зс]|[зд]?[ао](?:т|дн[оа])?|с(?:м[еи])?|а[пб]ч)-?)?ху(?:[яйиеёю]|л+и(?!ган)).*?|бл(?:[эя]|еа?)(?:[дт][ьъ]?)?|\S*?(?:п(?:[иеё]зд|ид[аое]?р|ед(?:р(?!о)|[аое]р|ик)|охую)|бля(?:[дбц]|тс)|[ое]ху[яйиеё]|хуйн).*?|(?:о[тб]?|про|на|вы)?м(?:анд(?:[ауеыи](?:л(?:и[сзщ])?[ауеиы])?|ой|[ао]в.*?|юк(?:ов|[ауи])?|е[нт]ь|ища)|уд(?:[яаиое].+?|е?н(?:[ьюия]|ей))|[ао]л[ао]ф[ьъ](?:[яиюе]|[еёо]й))|елд[ауые].*?|ля[тд]ь|(?:[нз]а|по)х)\b
         """.trimIndent().toRegex()
+    }
+
+    const val REPLACEMENT_STRING = "****"
+
+    val REPLACEMENT_CONFIG by lazy {
+        TextReplacementConfig.builder()
+            .match(SWEAR_REGEX.pattern)
+            .replacement(REPLACEMENT_STRING)
+            .build()
     }
 }

--- a/modules/antiswear/src/test/kotlin/ru/astrainteractive/aspekt/module/antiswear/util/SwearRuRegexTest.kt
+++ b/modules/antiswear/src/test/kotlin/ru/astrainteractive/aspekt/module/antiswear/util/SwearRuRegexTest.kt
@@ -1,0 +1,19 @@
+package ru.astrainteractive.aspekt.module.antiswear.util
+
+import net.kyori.adventure.text.Component
+import org.junit.Test
+
+class SwearRuRegexTest {
+    @Test
+    fun GIVEN_swear_WHEN_regex_THEN_match() {
+        assert(SwearRuRegex.SWEAR_REGEX.matches("бля"))
+        assert(SwearRuRegex.SWEAR_REGEX.matches("еблан"))
+    }
+
+    @Test
+    fun GIVEN_component_with_swears_WHEN_replace_by_regex_THEN_contains_replacement() {
+        val component = Component.text("бля урод ебаный гандон")
+        val replaced = component.replaceText(SwearRuRegex.REPLACEMENT_CONFIG)
+        assert(replaced.toString().contains(SwearRuRegex.REPLACEMENT_STRING))
+    }
+}


### PR DESCRIPTION
As it turns out, it doesn't work on jvm 21 for some reason. The swear just not replaced