### PR TITLE
#74 add piston event into adminprivate

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ makeevrserg.java.ktarget=21
 # Project
 makeevrserg.project.name=AspeKt
 makeevrserg.project.group=ru.astrainteractive.aspekt
-makeevrserg.project.version.string=2.26.0
+makeevrserg.project.version.string=2.26.1
 makeevrserg.project.description=Essentials plugin for EmpireProjekt
 makeevrserg.project.developers=makeevrserg|Makeev Roman|makeevrserg@gmail.com
 makeevrserg.project.url=https://empireprojekt.ru

--- a/modules/adminprivate/src/main/kotlin/ru/astrainteractive/aspekt/module/adminprivate/event/AdminPrivateEvent.kt
+++ b/modules/adminprivate/src/main/kotlin/ru/astrainteractive/aspekt/module/adminprivate/event/AdminPrivateEvent.kt
@@ -16,6 +16,7 @@ import org.bukkit.event.block.BlockBurnEvent
 import org.bukkit.event.block.BlockExplodeEvent
 import org.bukkit.event.block.BlockFromToEvent
 import org.bukkit.event.block.BlockIgniteEvent
+import org.bukkit.event.block.BlockPistonEvent
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.block.BlockSpreadEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
@@ -262,5 +263,15 @@ internal class AdminPrivateEvent(
                 flag = ChunkFlag.PLACE
             )
         }
+    }
+
+    val pistonEvent = DSLEvent<BlockPistonEvent>(eventListener, plugin) { e ->
+        handleDefault(
+            retractKey = RetractKey.Vararg(e.block.location.chunk, "BlockPistonEvent"),
+            e = e,
+            adminChunk = e.block.location.chunk.adminChunk,
+            player = null,
+            flag = ChunkFlag.PLACE
+        )
     }
 }


### PR DESCRIPTION
### Background
When players place pistons outside private, they can still fly inside admin chunks
### Changes
- Add check for pistons for admin private events